### PR TITLE
cleanup imports

### DIFF
--- a/src/ExtendedConv.jl
+++ b/src/ExtendedConv.jl
@@ -5,8 +5,16 @@
 
 module ExtendedConv
 
-using DrWatson
-import Pkg; Pkg.instantiate()
+using Flux
+using LinearAlgebra
+using PyPlot: Figure
+using JOLI
+using SetIntersectionProjection
+using SparseArrays
+using Optim
+
+import Base.+, Base.*
+import DrWatson: _wsave
 
 # Utilities
 include("./utils/savefig.jl")

--- a/src/extension/extension.jl
+++ b/src/extension/extension.jl
@@ -6,14 +6,6 @@ export extended_conv_op
 export var_proj_optim
 export var_proj_op
 
-using Flux
-using LinearAlgebra
-using JOLI
-using SetIntersectionProjection
-using SparseArrays
-using Optim
-
-
 mutable struct Conv_cds
     diagonals
     offsets

--- a/src/extension/flux_optim.jl
+++ b/src/extension/flux_optim.jl
@@ -1,7 +1,5 @@
 export loss_flux
 
-using Flux
-
 function loss_flux(func_val, dw, w, z, y, G)
 
 

--- a/src/utils/savefig.jl
+++ b/src/utils/savefig.jl
@@ -4,7 +4,4 @@
 
 export _wsave
 
-using PyPlot: Figure
-import DrWatson: _wsave
-
 _wsave(s, fig::Figure; dpi::Int=300) = fig.savefig(s, bbox_inches="tight", dpi=dpi)

--- a/src/visualization/visualization.jl
+++ b/src/visualization/visualization.jl
@@ -4,12 +4,6 @@
 
 export filter_normalization, sol_traj
 
-import Base.+, Base.*
-
-using Flux
-using LinearAlgebra
-
-
 function filter_normalization(theta::Flux.Params)
 
     d = deepcopy(theta)


### PR DESCRIPTION
Follow julia convention, all "using" should be in the module definition (also avoids duplicate imports")
